### PR TITLE
bt-50: Create loader component and styles

### DIFF
--- a/frontend/src/bundles/common/components/loader/loader.tsx
+++ b/frontend/src/bundles/common/components/loader/loader.tsx
@@ -1,0 +1,23 @@
+import { CircularProgress } from '@mui/material';
+
+import styles from './styles.module.scss';
+
+type Properties = {
+    size?: number;
+    variant?: 'determinate' | 'indeterminate';
+    value?: number;
+};
+
+const Loader = ({
+    size,
+    variant = 'indeterminate',
+    value,
+}: Properties): JSX.Element => {
+    return (
+        <div className={styles.loader}>
+            <CircularProgress size={size} variant={variant} value={value} />
+        </div>
+    );
+};
+
+export { Loader };

--- a/frontend/src/bundles/common/components/loader/styles.module.scss
+++ b/frontend/src/bundles/common/components/loader/styles.module.scss
@@ -1,0 +1,6 @@
+.loader {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 100%;
+}


### PR DESCRIPTION
I have added loader component and this is what it looks like

<img width="1433" alt="Screenshot 2023-08-22 at 14 44 57" src="https://github.com/BinaryStudioAcademy/bsa-2023-bsa-talents/assets/116720360/5515ae51-d5d8-4e09-845a-94e4af4e5a8d">

<img width="653" alt="Screenshot 2023-08-22 at 14 42 49" src="https://github.com/BinaryStudioAcademy/bsa-2023-bsa-talents/assets/116720360/bf5ff122-98c5-4549-aa5a-5d65741afac7">


