### PR TITLE
bt-92: * apply className to FormControlLabel

### DIFF
--- a/frontend/src/bundles/common/components/checkbox/checkbox.tsx
+++ b/frontend/src/bundles/common/components/checkbox/checkbox.tsx
@@ -47,11 +47,11 @@ const Checkbox: React.FC<Properties> = ({
                     checked={isChecked}
                     required={isRequired}
                     disabled={isDisabled}
-                    className={getValidClassNames(className)}
                     icon={checkboxIcon}
                     checkedIcon={checkboxIconChecked}
                 />
             }
+            className={getValidClassNames(className)}
             label={label}
         />
     ) : (


### PR DESCRIPTION
I just moved to FormControlLabel if checkbox is created with label. Because before it was impossible to customize label style.
Now we can do it by changing MUI classname  in next way:
![Screenshot_8](https://github.com/BinaryStudioAcademy/bsa-2023-bsa-talents/assets/67747035/e7ca42b2-88e2-43a6-8a65-c0b856429b2a)
![Screenshot_4](https://github.com/BinaryStudioAcademy/bsa-2023-bsa-talents/assets/67747035/8c770053-b0a1-485e-9e57-6ac0acc8039c)
![Screenshot_3](https://github.com/BinaryStudioAcademy/bsa-2023-bsa-talents/assets/67747035/73e8d400-6bbc-4f3c-9abd-ca5a91225b77)
