### PR TITLE
bt-133: Disable some linter rules for d.ts files in frontend

### DIFF
--- a/frontend/.eslintrc.yml
+++ b/frontend/.eslintrc.yml
@@ -31,6 +31,13 @@ overrides:
               - off
     - files:
           - vite-env.d.ts
+          - typography.d.ts
       rules:
           unicorn/prevent-abbreviations:
+              - off
+    - files:
+          - typography.d.ts
+          - theme.d.ts
+      rules:
+          '@typescript-eslint/consistent-type-definitions':
               - off

--- a/frontend/.eslintrc.yml
+++ b/frontend/.eslintrc.yml
@@ -30,14 +30,9 @@ overrides:
           import/no-default-export:
               - off
     - files:
-          - vite-env.d.ts
-          - typography.d.ts
+          - '*.d.ts'
       rules:
           unicorn/prevent-abbreviations:
               - off
-    - files:
-          - typography.d.ts
-          - theme.d.ts
-      rules:
           '@typescript-eslint/consistent-type-definitions':
               - off

--- a/frontend/src/bundles/common/themes/color-theme/theme.d.ts
+++ b/frontend/src/bundles/common/themes/color-theme/theme.d.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/consistent-type-definitions */
 import {
     type Palette as MuiPalette,
     type PaletteOptions as MuiPaletteOptions,

--- a/frontend/src/bundles/common/themes/typography-theme/typography.d.ts
+++ b/frontend/src/bundles/common/themes/typography-theme/typography.d.ts
@@ -1,5 +1,3 @@
-/* eslint-disable unicorn/prevent-abbreviations */
-/* eslint-disable @typescript-eslint/consistent-type-definitions */
 import {
     type TypographyPropsVariantOverrides as MuiTypographyPropertiesVariantOverrides,
     type TypographyVariants as MuiTypographyVariants,


### PR DESCRIPTION
Disabled the linter rule for `typography.d.ts` and `theme.d.ts` files and removed comments in these files.