### PR TITLE
bt-72: Create user profile(hard skills and user details)

### DIFF
--- a/backend/src/common/database/enums/database-table-name.enum.ts
+++ b/backend/src/common/database/enums/database-table-name.enum.ts
@@ -1,9 +1,12 @@
 const DatabaseTableName = {
     MIGRATIONS: 'migrations',
     USERS: 'users',
+    USER_DETAILS: 'user_details',
     FILES: 'files',
     TALENT_BADGES: 'talent_badges',
     BSA_BADGES: 'bsa_badges',
+    TALENT_HARD_SKILLS: 'talent_hard_skills',
+    HARD_SKILLS: 'hard_skills',
 } as const;
 
 export { DatabaseTableName };

--- a/backend/src/migrations/20230828113106_add_hard_skills_table.ts
+++ b/backend/src/migrations/20230828113106_add_hard_skills_table.ts
@@ -1,0 +1,41 @@
+import { type Knex } from 'knex';
+
+const uuid = 'uuid_generate_v4()';
+const constraintName = 'hard_skills_pkey';
+
+const TABLE_NAME = 'hard_skills';
+
+const ColumnName = {
+    ID: 'id',
+    NAME: 'name',
+    CREATED_AT: 'created_at',
+    UPDATED_AT: 'updated_at',
+};
+
+async function up(knex: Knex): Promise<void> {
+    await knex.raw('CREATE EXTENSION IF NOT EXISTS "uuid-ossp";');
+
+    return knex.schema.createTable(TABLE_NAME, (table) => {
+        table
+            .uuid(ColumnName.ID)
+            .unique()
+            .notNullable()
+            .defaultTo(knex.raw(uuid))
+            .primary({ constraintName });
+        table.string(ColumnName.NAME).notNullable();
+        table
+            .dateTime(ColumnName.CREATED_AT)
+            .notNullable()
+            .defaultTo(knex.fn.now());
+        table
+            .dateTime(ColumnName.UPDATED_AT)
+            .notNullable()
+            .defaultTo(knex.fn.now());
+    });
+}
+
+async function down(knex: Knex): Promise<void> {
+    return knex.schema.dropTableIfExists(TABLE_NAME);
+}
+
+export { down, up };

--- a/backend/src/migrations/20230828113256_add_user_details_table.ts
+++ b/backend/src/migrations/20230828113256_add_user_details_table.ts
@@ -1,0 +1,121 @@
+import { type Knex } from 'knex';
+
+const uuid = 'uuid_generate_v4()';
+const constraintName = 'user_details_pkey';
+
+const TableName = {
+    USERS: 'users',
+    USER_DETAILS: 'user_details',
+    FILES: 'files',
+};
+const TABLE_NAME = 'user_details';
+
+const ColumnName = {
+    ID: 'id',
+    USER_ID: 'user_id',
+    IS_APPROVED: 'is_approved',
+    DENIED_REASON: 'denied_reason',
+    IS_HIRED: 'is_hired',
+    PROFILE_NAME: 'profile_name',
+    SALARY_EXPECTATION: 'salary_expectation',
+    HIRED_SALARY: 'hired_salary',
+    JOB_TITLE: 'job_title',
+    LOCATION: 'location',
+    EXPERIENCE_YEARS: 'experience_years',
+    EMPLOYMENT_TYPE: 'employment_type',
+    DESCRIPTION: 'description',
+    ENGLISH_LEVEL: 'english_level',
+    NOT_CONSIDERED: 'not_considered',
+    PREFERRED_LANGUAGES: 'preferred_languages',
+    PROJECT_LINKS: 'project_links',
+    PHOTO_ID: 'photo_id',
+    FULL_NAME: 'full_name',
+    PHONE: 'phone',
+    LINKEDIN_LINK: 'linkedin_link',
+    COMPANY_NAME: 'company_name',
+    COMPANY_LOGO_ID: 'company_logo_id',
+    COMPANY_WEBSITE: 'company_website',
+    EMPOYER_POSITION: 'employer_position',
+    CV_ID: 'cv_id',
+    CREATED_AT: 'created_at',
+    UPDATED_AT: 'updated_at',
+};
+
+const RelationRule = {
+    CASCADE: 'CASCADE',
+    SET_NULL: 'SET NULL',
+} as const;
+
+async function up(knex: Knex): Promise<void> {
+    await knex.raw('CREATE EXTENSION IF NOT EXISTS "uuid-ossp";');
+
+    return knex.schema.createTable(TABLE_NAME, (table) => {
+        table
+            .uuid(ColumnName.ID)
+            .unique()
+            .notNullable()
+            .defaultTo(knex.raw(uuid))
+            .primary({ constraintName });
+        table
+            .uuid(ColumnName.USER_ID)
+            .unique()
+            .notNullable()
+            .references(ColumnName.ID)
+            .inTable(TableName.USERS)
+            .onUpdate(RelationRule.CASCADE)
+            .onDelete(RelationRule.CASCADE);
+        table.boolean(ColumnName.IS_APPROVED).defaultTo(false);
+        table.string(ColumnName.DENIED_REASON);
+        table.boolean(ColumnName.IS_HIRED).defaultTo(false);
+        table.string(ColumnName.PROFILE_NAME);
+        table.integer(ColumnName.SALARY_EXPECTATION);
+        table.integer(ColumnName.HIRED_SALARY);
+        table.string(ColumnName.JOB_TITLE);
+        table.string(ColumnName.LOCATION);
+        table.integer(ColumnName.EXPERIENCE_YEARS);
+        table.specificType(ColumnName.EMPLOYMENT_TYPE, 'text[]');
+        table.text(ColumnName.DESCRIPTION);
+        table.string(ColumnName.ENGLISH_LEVEL);
+        table.specificType(ColumnName.NOT_CONSIDERED, 'text[]');
+        table.specificType(ColumnName.PREFERRED_LANGUAGES, 'text[]');
+        table.specificType(ColumnName.PROJECT_LINKS, 'text[]');
+        table
+            .uuid(ColumnName.PHOTO_ID)
+            .references(ColumnName.ID)
+            .inTable(TableName.FILES)
+            .onUpdate(RelationRule.CASCADE)
+            .onDelete(RelationRule.SET_NULL);
+        table.string(ColumnName.FULL_NAME).notNullable();
+        table.string(ColumnName.PHONE);
+        table.string(ColumnName.LINKEDIN_LINK);
+        table.string(ColumnName.COMPANY_NAME);
+        table
+            .uuid(ColumnName.COMPANY_LOGO_ID)
+            .references(ColumnName.ID)
+            .inTable(TableName.FILES)
+            .onUpdate(RelationRule.CASCADE)
+            .onDelete(RelationRule.SET_NULL);
+        table.string(ColumnName.COMPANY_WEBSITE);
+        table.string(ColumnName.EMPOYER_POSITION);
+        table
+            .uuid(ColumnName.CV_ID)
+            .references(ColumnName.ID)
+            .inTable(TableName.FILES)
+            .onUpdate(RelationRule.CASCADE)
+            .onDelete(RelationRule.SET_NULL);
+        table
+            .dateTime(ColumnName.CREATED_AT)
+            .notNullable()
+            .defaultTo(knex.fn.now());
+        table
+            .dateTime(ColumnName.UPDATED_AT)
+            .notNullable()
+            .defaultTo(knex.fn.now());
+    });
+}
+
+async function down(knex: Knex): Promise<void> {
+    return knex.schema.dropTableIfExists(TABLE_NAME);
+}
+
+export { down, up };

--- a/backend/src/migrations/20230828113344_update_talent_badges_table.ts
+++ b/backend/src/migrations/20230828113344_update_talent_badges_table.ts
@@ -1,0 +1,37 @@
+import { type Knex } from 'knex';
+
+const TableName = {
+    USER_DETAILS: 'user_details',
+    TALENT_BADGES: 'talent_badges',
+};
+
+const ColumnName = {
+    ID: 'id',
+    USER_DETAILS_ID: 'user_details_id',
+};
+
+const RelationRule = {
+    CASCADE: 'CASCADE',
+    SET_NULL: 'SET NULL',
+} as const;
+
+async function up(knex: Knex): Promise<void> {
+    await knex.raw('CREATE EXTENSION IF NOT EXISTS "uuid-ossp";');
+
+    return knex.schema.alterTable(TableName.TALENT_BADGES, (table) => {
+        table
+            .uuid(ColumnName.USER_DETAILS_ID)
+            .references(ColumnName.ID)
+            .inTable(TableName.USER_DETAILS)
+            .onUpdate(RelationRule.CASCADE)
+            .onDelete(RelationRule.SET_NULL);
+    });
+}
+
+async function down(knex: Knex): Promise<void> {
+    return knex.schema.alterTable(TableName.TALENT_BADGES, (table) => {
+        table.dropColumn(ColumnName.USER_DETAILS_ID);
+    });
+}
+
+export { down, up };

--- a/backend/src/migrations/20230828113412_add_talent_hard_skills_table.ts
+++ b/backend/src/migrations/20230828113412_add_talent_hard_skills_table.ts
@@ -1,0 +1,63 @@
+import { type Knex } from 'knex';
+
+const uuid = 'uuid_generate_v4()';
+const constraintName = 'talent_hard_skills_pkey';
+
+const TableName = {
+    USER_DETAILS: 'user_details',
+    TALENT_HARD_SKILLS: 'talent_hard_skills',
+    HARD_SKILLS: 'hard_skills',
+};
+
+const ColumnName = {
+    ID: 'id',
+    HARD_SKILL_ID: 'hard_skill_id',
+    USER_DETAILS_ID: 'user_details_id',
+    CREATED_AT: 'created_at',
+    UPDATED_AT: 'updated_at',
+};
+
+const RelationRule = {
+    CASCADE: 'CASCADE',
+} as const;
+
+async function up(knex: Knex): Promise<void> {
+    await knex.raw('CREATE EXTENSION IF NOT EXISTS "uuid-ossp";');
+
+    return knex.schema.createTable(TableName.TALENT_HARD_SKILLS, (table) => {
+        table
+            .uuid(ColumnName.ID)
+            .unique()
+            .notNullable()
+            .defaultTo(knex.raw(uuid))
+            .primary({ constraintName });
+        table
+            .uuid(ColumnName.HARD_SKILL_ID)
+            .unique()
+            .notNullable()
+            .references(ColumnName.ID)
+            .inTable(TableName.HARD_SKILLS)
+            .onUpdate(RelationRule.CASCADE)
+            .onDelete(RelationRule.CASCADE);
+        table
+            .uuid(ColumnName.USER_DETAILS_ID)
+            .references(ColumnName.ID)
+            .inTable(TableName.USER_DETAILS)
+            .onUpdate(RelationRule.CASCADE)
+            .onDelete(RelationRule.CASCADE);
+        table
+            .dateTime(ColumnName.CREATED_AT)
+            .notNullable()
+            .defaultTo(knex.fn.now());
+        table
+            .dateTime(ColumnName.UPDATED_AT)
+            .notNullable()
+            .defaultTo(knex.fn.now());
+    });
+}
+
+async function down(knex: Knex): Promise<void> {
+    return knex.schema.dropTableIfExists(TableName.TALENT_HARD_SKILLS);
+}
+
+export { down, up };


### PR DESCRIPTION
I've added hard_skills, user_details and talent_hard_skills tables. Linked talent_badges with user_details_id.
The sequence with Veronika Sirak's migrations is preserved, and my migrations follow Veronika's.
This is a new branch and pull request because I accidentally merged development and commits from other branches showed up there.