### PR TITLE
bt-72: Add expectation salary type(UAH, USD, EUR)

### DIFF
--- a/backend/src/common/enums/currency-type.enum.ts
+++ b/backend/src/common/enums/currency-type.enum.ts
@@ -1,0 +1,7 @@
+const CurrencyType = {
+    UAH: 'UAH',
+    USD: 'USD',
+    EUR: 'EUR',
+} as const;
+
+export { CurrencyType };

--- a/backend/src/common/enums/enums.ts
+++ b/backend/src/common/enums/enums.ts
@@ -1,3 +1,4 @@
+export { CurrencyType } from './currency-type.enum.js';
 export { UserRole } from './user-role.enum.js';
 export {
     ApiPath,

--- a/backend/src/migrations/20230828154649_update_user_details_table.ts
+++ b/backend/src/migrations/20230828154649_update_user_details_table.ts
@@ -1,0 +1,26 @@
+import { type Knex } from 'knex';
+
+import { CurrencyType } from '~/common/enums/enums.js';
+
+const TABLE_NAME = 'users';
+
+const ColumnName = {
+    SALARY_EXPECTATION_TYPE: 'salary_expectation_type',
+};
+
+async function up(knex: Knex): Promise<void> {
+    return knex.schema.alterTable(TABLE_NAME, (table) => {
+        table.enum(
+            ColumnName.SALARY_EXPECTATION_TYPE,
+            Object.values(CurrencyType),
+        );
+    });
+}
+
+async function down(knex: Knex): Promise<void> {
+    return knex.schema.alterTable(TABLE_NAME, (table) => {
+        table.dropColumn(ColumnName.SALARY_EXPECTATION_TYPE);
+    });
+}
+
+export { down, up };


### PR DESCRIPTION
I've added to user_details table enum with (UAH, USD, EUR) fields for salary_expectation_type that comes from talent registration flow.