### PR TITLE
bt-138: Modify list of white routes

### DIFF
--- a/backend/src/common/plugins/authorization/authorization.plugin.ts
+++ b/backend/src/common/plugins/authorization/authorization.plugin.ts
@@ -28,7 +28,7 @@ const authorizationPlugin: FastifyPluginCallback<AuthOptions> = (
             headers: { authorization },
         } = request;
 
-        if (checkWhiteRoute(routerPath, routerMethod)) {
+        if (checkWhiteRoute({ routerPath, routerMethod })) {
             return;
         }
 

--- a/backend/src/common/server-application/constants/api.constants.ts
+++ b/backend/src/common/server-application/constants/api.constants.ts
@@ -2,8 +2,26 @@ import { AuthApiPath } from '~/bundles/auth/enums/enums.js';
 import { ApiPath } from '~/common/enums/enums.js';
 
 const WHITE_ROUTES = [
-    `/api/v1${ApiPath.AUTH}${AuthApiPath.SIGN_UP}`,
-    `/api/v1${ApiPath.AUTH}${AuthApiPath.SIGN_IN}`,
+    {
+        routerPath: `/api/v1${ApiPath.AUTH}${AuthApiPath.SIGN_UP}`,
+        methods: ['POST'],
+    },
+    {
+        routerPath: `/api/v1${ApiPath.AUTH}${AuthApiPath.SIGN_IN}`,
+        methods: ['POST'],
+    },
+    {
+        routerPath: `/v1${ApiPath.DOCUMENTATION}/`,
+        methods: ['GET'],
+    },
+    {
+        routerPath: `/v1${ApiPath.DOCUMENTATION}/static/*`,
+        methods: ['GET'],
+    },
+    {
+        routerPath: `/v1${ApiPath.DOCUMENTATION}/json`,
+        methods: ['GET'],
+    },
 ];
 
 export { WHITE_ROUTES };

--- a/backend/src/common/server-application/constants/api.constants.ts
+++ b/backend/src/common/server-application/constants/api.constants.ts
@@ -3,23 +3,15 @@ import { ApiPath } from '~/common/enums/enums.js';
 
 const WHITE_ROUTES = [
     {
-        routerPath: `/api/v1${ApiPath.AUTH}${AuthApiPath.SIGN_UP}`,
+        path: `/api/v1${ApiPath.AUTH}${AuthApiPath.SIGN_UP}`,
         methods: ['POST'],
     },
     {
-        routerPath: `/api/v1${ApiPath.AUTH}${AuthApiPath.SIGN_IN}`,
+        path: `/api/v1${ApiPath.AUTH}${AuthApiPath.SIGN_IN}`,
         methods: ['POST'],
     },
     {
-        routerPath: `/v1${ApiPath.DOCUMENTATION}/`,
-        methods: ['GET'],
-    },
-    {
-        routerPath: `/v1${ApiPath.DOCUMENTATION}/static/*`,
-        methods: ['GET'],
-    },
-    {
-        routerPath: `/v1${ApiPath.DOCUMENTATION}/json`,
+        path: `/v1${ApiPath.DOCUMENTATION}/*`,
         methods: ['GET'],
     },
 ];

--- a/backend/src/common/server-application/helpers/check-white-route.helper.ts
+++ b/backend/src/common/server-application/helpers/check-white-route.helper.ts
@@ -1,19 +1,17 @@
 import { WHITE_ROUTES } from '../constants/api.constants.js';
 
-const checkWhiteRoute = (route: string, method: string): boolean => {
-    for (const whiteRoute of WHITE_ROUTES) {
-        const isMethodMatch = whiteRoute.methods.includes(method);
-        if (!isMethodMatch) {
-            continue;
-        }
-
-        const routePattern = whiteRoute.routerPath.replace('*', '.*');
+const checkWhiteRoute = ({
+    routerPath,
+    routerMethod,
+}: {
+    routerPath: string;
+    routerMethod: string;
+}): boolean => {
+    return WHITE_ROUTES.some((route) => {
+        const routePattern = route.path.replace('*', '.*');
         const regex = new RegExp(`^${routePattern}$`);
-        if (regex.test(route)) {
-            return true;
-        }
-    }
-    return false;
+        return regex.test(routerPath) && route.methods.includes(routerMethod);
+    });
 };
 
 export { checkWhiteRoute };

--- a/backend/src/common/server-application/helpers/check-white-route.helper.ts
+++ b/backend/src/common/server-application/helpers/check-white-route.helper.ts
@@ -1,7 +1,19 @@
 import { WHITE_ROUTES } from '../constants/api.constants.js';
 
 const checkWhiteRoute = (route: string, method: string): boolean => {
-    return method === 'GET' && WHITE_ROUTES.includes(route);
+    for (const whiteRoute of WHITE_ROUTES) {
+        const isMethodMatch = whiteRoute.methods.includes(method);
+        if (!isMethodMatch) {
+            continue;
+        }
+
+        const routePattern = whiteRoute.routerPath.replace('*', '.*');
+        const regex = new RegExp(`^${routePattern}$`);
+        if (regex.test(route)) {
+            return true;
+        }
+    }
+    return false;
 };
 
 export { checkWhiteRoute };

--- a/shared/src/enums/api-path.enum.ts
+++ b/shared/src/enums/api-path.enum.ts
@@ -1,6 +1,7 @@
 const ApiPath = {
     USERS: '/users',
     AUTH: '/auth',
+    DOCUMENTATION: '/documentation',
 } as const;
 
 export { ApiPath };


### PR DESCRIPTION
I changed format of white routes list to required.
![routes](https://github.com/BinaryStudioAcademy/bsa-2023-bsa-talents/assets/67747035/bdc2b633-d91a-48e0-ba1c-c388a21fda69)
Also modified helper to work with new format and used regex to handle routes like:
`/v1/documentation/static/*`
![helper](https://github.com/BinaryStudioAcademy/bsa-2023-bsa-talents/assets/67747035/5d2843df-1749-4135-a86a-3f5f235b81c2)
