### PR TITLE
bt-209: Change swagger url and paths description

### DIFF
--- a/backend/src/bundles/auth/auth.controller.ts
+++ b/backend/src/bundles/auth/auth.controller.ts
@@ -18,6 +18,15 @@ import { ControllerBase } from '~/common/packages/packages.js';
 import { type AuthService } from './auth.service.js';
 import { AuthApiPath } from './enums/enums.js';
 
+/**
+ * @swagger
+ * components:
+ *   securitySchemes:
+ *     bearerAuth:
+ *       type: http
+ *       scheme: bearer
+ *       bearerFormat: JWT
+ */
 class AuthController extends ControllerBase {
     private authService: AuthService;
 
@@ -80,6 +89,8 @@ class AuthController extends ControllerBase {
      *                  format: email
      *                password:
      *                  type: string
+     *                role:
+     *                  $ref: '#/components/schemas/RoleEnum'
      *      responses:
      *        201:
      *          description: Successful operation
@@ -88,6 +99,14 @@ class AuthController extends ControllerBase {
      *              schema:
      *                type: object
      *                properties:
+     *                  id:
+     *                    type: string
+     *                    format: uuid
+     *                  email:
+     *                    type: string
+     *                    format: email
+     *                  role:
+     *                    $ref: '#/components/schemas/RoleEnum'
      *                  token:
      *                    type: string
      */
@@ -128,6 +147,14 @@ class AuthController extends ControllerBase {
      *              schema:
      *                type: object
      *                properties:
+     *                  id:
+     *                    type: string
+     *                    format: uuid
+     *                  email:
+     *                    type: string
+     *                    format: email
+     *                  role:
+     *                    $ref: '#/components/schemas/RoleEnum'
      *                  token:
      *                    type: string
      */
@@ -158,18 +185,6 @@ class AuthController extends ControllerBase {
      *           application/json:
      *             schema:
      *               $ref: '#/components/schemas/User'
-     *       401:
-     *         description: Unauthorized
-     *         content:
-     *           application/json:
-     *             schema:
-     *               $ref: '#/components/schemas/Error'
-     *       404:
-     *         description: User not found
-     *         content:
-     *           application/json:
-     *             schema:
-     *               $ref: '#/components/schemas/Error'
      */
 
     private async getCurrentUser(

--- a/backend/src/bundles/users/user.controller.ts
+++ b/backend/src/bundles/users/user.controller.ts
@@ -11,16 +11,23 @@ import { UsersApiPath } from './enums/enums.js';
  * @swagger
  * components:
  *    schemas:
+ *      RoleEnum:
+ *        type: string
+ *        enum:
+ *          - talent
+ *          - employer
+ *          - admin
  *      User:
  *        type: object
  *        properties:
  *          id:
- *            type: number
- *            format: number
- *            minimum: 1
+ *            type: string
+ *            format: uuid
  *          email:
  *            type: string
  *            format: email
+ *          role:
+ *            $ref: '#/components/schemas/RoleEnum'
  */
 class UserController extends ControllerBase {
     private userService: UserService;
@@ -40,6 +47,8 @@ class UserController extends ControllerBase {
     /**
      * @swagger
      * /users/:
+     *    security:
+     *        -bearerAuth: []
      *    get:
      *      tags: [Users]
      *      description: Returns an array of users

--- a/backend/src/common/server-application/constants/api.constants.ts
+++ b/backend/src/common/server-application/constants/api.constants.ts
@@ -11,7 +11,7 @@ const WHITE_ROUTES = [
         methods: ['POST'],
     },
     {
-        path: `/v1${ApiPath.DOCUMENTATION}/*`,
+        path: `/api/v1${ApiPath.DOCUMENTATION}/*`,
         methods: ['GET'],
     },
 ];

--- a/backend/src/common/server-application/constants/api.constants.ts
+++ b/backend/src/common/server-application/constants/api.constants.ts
@@ -11,7 +11,7 @@ const WHITE_ROUTES = [
         methods: ['POST'],
     },
     {
-        path: `/api/v1${ApiPath.DOCUMENTATION}/*`,
+        path: `/api/v1${ApiPath.DOCUMENTATION}*`,
         methods: ['GET'],
     },
 ];

--- a/backend/src/common/server-application/server-app-base.ts
+++ b/backend/src/common/server-application/server-app-base.ts
@@ -94,7 +94,7 @@ class ServerAppBase implements ServerApp {
                 });
 
                 await this.app.register(swaggerUi, {
-                    routePrefix: `${it.version}/documentation`,
+                    routePrefix: `api/${it.version}/documentation`,
                 });
             }),
         );

--- a/shared/src/bundles/users/validation-schemas/user-sign-in.validation-schema.ts
+++ b/shared/src/bundles/users/validation-schemas/user-sign-in.validation-schema.ts
@@ -2,7 +2,7 @@ import joi from 'joi';
 
 import { UserValidationMessage } from '../enums/enums.js';
 import { type UserSignInRequestDto } from '../types/types.js';
-import { AUTH_CONSTANTS } from './auth-constants';
+import { AUTH_CONSTANTS } from './auth-constants.js';
 
 const userSignIn = joi.object<UserSignInRequestDto, true>({
     email: joi


### PR DESCRIPTION
Now swagger documentation can be accessed by 'http://localhost:3001/api/v1/documentation/'
![1](https://github.com/BinaryStudioAcademy/bsa-2023-bsa-talents/assets/67747035/10664357-7945-4bc5-bab3-56dea4982bdb)
![2](https://github.com/BinaryStudioAcademy/bsa-2023-bsa-talents/assets/67747035/25f2969a-17b3-4fa2-ba0b-dc697a36ad0a)
![3](https://github.com/BinaryStudioAcademy/bsa-2023-bsa-talents/assets/67747035/154820d6-ae57-477f-8070-be86f734a45e)
![4](https://github.com/BinaryStudioAcademy/bsa-2023-bsa-talents/assets/67747035/4563e3d6-a2c7-4f03-9230-ceaac52052e8)
