### PR TITLE
bt-252: create avatar common component

### DIFF
--- a/frontend/src/assets/css/variables.scss
+++ b/frontend/src/assets/css/variables.scss
@@ -71,7 +71,7 @@
     // Avatar
     --avatar-color: #7a77fd;
     --avatar-online-color: var(--mountain-meadow);
-    --avatar-offline-color: var(--torch-red);
+    --avatar-offline-color: var(--nepal);
 
     // *Font*
 

--- a/frontend/src/assets/css/variables.scss
+++ b/frontend/src/assets/css/variables.scss
@@ -68,6 +68,11 @@
     // Sidebar
     --sidebar-width: 80px;
 
+    // Avatar
+    --avatar-color: #7a77fd;
+    --avatar-online-color: var(--mountain-meadow);
+    --avatar-offline-color: var(--torch-red);
+
     // *Font*
 
     // Font family

--- a/frontend/src/bundles/common/components/avatar/components.ts
+++ b/frontend/src/bundles/common/components/avatar/components.ts
@@ -1,0 +1,5 @@
+export { Avatar, type AvatarProperties } from './components/avatar/avatar.js';
+export {
+    HeaderAvatar,
+    type HeaderAvatarProperties,
+} from './components/header-avatar/header-avatar.js';

--- a/frontend/src/bundles/common/components/avatar/components/avatar/avatar.tsx
+++ b/frontend/src/bundles/common/components/avatar/components/avatar/avatar.tsx
@@ -21,9 +21,7 @@ const Avatar: React.FC<Properties> = ({
                 small ? styles.small : '',
             )}
             {...props}
-        >
-            {/* default icon/text */}
-        </MUIAvatar>
+        ></MUIAvatar>
     );
 };
 

--- a/frontend/src/bundles/common/components/avatar/components/avatar/avatar.tsx
+++ b/frontend/src/bundles/common/components/avatar/components/avatar/avatar.tsx
@@ -1,0 +1,31 @@
+import { Avatar as MUIAvatar, type AvatarProps } from '@mui/material';
+
+import { getValidClassNames } from '~/bundles/common/helpers/helpers.js';
+
+import styles from './styles.module.scss';
+
+type Properties = AvatarProps & {
+    small?: boolean;
+};
+
+const Avatar: React.FC<Properties> = ({
+    small = false,
+    className,
+    ...props
+}) => {
+    return (
+        <MUIAvatar
+            className={getValidClassNames(
+                className,
+                styles.avatar,
+                small ? styles.small : '',
+            )}
+            {...props}
+        >
+            {/* default icon/text */}
+        </MUIAvatar>
+    );
+};
+
+export { type Properties as AvatarProperties };
+export { Avatar };

--- a/frontend/src/bundles/common/components/avatar/components/avatar/avatar.tsx
+++ b/frontend/src/bundles/common/components/avatar/components/avatar/avatar.tsx
@@ -18,7 +18,7 @@ const Avatar: React.FC<Properties> = ({
             className={getValidClassNames(
                 className,
                 styles.avatar,
-                small ? styles.small : '',
+                small && styles.small,
             )}
             {...props}
         ></MUIAvatar>

--- a/frontend/src/bundles/common/components/avatar/components/avatar/avatar.tsx
+++ b/frontend/src/bundles/common/components/avatar/components/avatar/avatar.tsx
@@ -5,11 +5,11 @@ import { getValidClassNames } from '~/bundles/common/helpers/helpers.js';
 import styles from './styles.module.scss';
 
 type Properties = AvatarProps & {
-    small?: boolean;
+    isSmall?: boolean;
 };
 
 const Avatar: React.FC<Properties> = ({
-    small = false,
+    isSmall = false,
     className,
     ...props
 }) => {
@@ -18,7 +18,7 @@ const Avatar: React.FC<Properties> = ({
             className={getValidClassNames(
                 className,
                 styles.avatar,
-                small && styles.small,
+                isSmall && styles.small,
             )}
             {...props}
         ></MUIAvatar>

--- a/frontend/src/bundles/common/components/avatar/components/avatar/styles.module.scss
+++ b/frontend/src/bundles/common/components/avatar/components/avatar/styles.module.scss
@@ -8,4 +8,5 @@
 .small {
     width: 40px;
     height: 40px;
+    border-radius: 10px;
 }

--- a/frontend/src/bundles/common/components/avatar/components/avatar/styles.module.scss
+++ b/frontend/src/bundles/common/components/avatar/components/avatar/styles.module.scss
@@ -1,0 +1,11 @@
+.avatar {
+    width: 48px;
+    height: 48px;
+    background-color: var(--avatar-color);
+    border-radius: 12px;
+}
+
+.small {
+    width: 40px;
+    height: 40px;
+}

--- a/frontend/src/bundles/common/components/avatar/components/header-avatar/header-avatar.tsx
+++ b/frontend/src/bundles/common/components/avatar/components/header-avatar/header-avatar.tsx
@@ -1,0 +1,43 @@
+import { Badge as MUIBadge } from '@mui/material';
+
+import { getValidClassNames } from '~/bundles/common/helpers/helpers.js';
+
+import { Avatar, type AvatarProperties } from '../avatar/avatar.js';
+import styles from './styles.module.scss';
+
+type Properties = AvatarProperties & {
+    isOnline?: boolean;
+};
+
+const HeaderAvatar: React.FC<Properties> = ({
+    className,
+    isOnline,
+    ...props
+}) => {
+    return (
+        <div className={className}>
+            <MUIBadge
+                classes={{
+                    badge: getValidClassNames(
+                        styles.badge,
+                        isOnline ? styles.badgeOnline : styles.badgeOffline,
+                    ),
+                }}
+                overlap="circular"
+                anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+                variant="dot"
+            >
+                <Avatar
+                    small
+                    className={getValidClassNames(styles.headerAvatar)}
+                    {...props}
+                >
+                    {/* default icon/text */}
+                </Avatar>
+            </MUIBadge>
+        </div>
+    );
+};
+
+export { type Properties as HeaderAvatarProperties };
+export { HeaderAvatar };

--- a/frontend/src/bundles/common/components/avatar/components/header-avatar/header-avatar.tsx
+++ b/frontend/src/bundles/common/components/avatar/components/header-avatar/header-avatar.tsx
@@ -31,9 +31,7 @@ const HeaderAvatar: React.FC<Properties> = ({
                     small
                     className={getValidClassNames(styles.headerAvatar)}
                     {...props}
-                >
-                    {/* default icon/text */}
-                </Avatar>
+                ></Avatar>
             </MUIBadge>
         </div>
     );

--- a/frontend/src/bundles/common/components/avatar/components/header-avatar/header-avatar.tsx
+++ b/frontend/src/bundles/common/components/avatar/components/header-avatar/header-avatar.tsx
@@ -28,7 +28,7 @@ const HeaderAvatar: React.FC<Properties> = ({
                 variant="dot"
             >
                 <Avatar
-                    small
+                    isSmall
                     className={getValidClassNames(styles.headerAvatar)}
                     {...props}
                 ></Avatar>

--- a/frontend/src/bundles/common/components/avatar/components/header-avatar/styles.module.scss
+++ b/frontend/src/bundles/common/components/avatar/components/header-avatar/styles.module.scss
@@ -1,0 +1,15 @@
+.headerAvatar {
+    border-radius: 50%;
+}
+
+.badge {
+    box-shadow: 0 0 0 2px #ffffff;
+}
+
+.badgeOnline {
+    background-color: var(--avatar-online-color);
+}
+
+.badgeOffline {
+    background-color: var(--avatar-offline-color);
+}

--- a/frontend/src/bundles/common/components/components.ts
+++ b/frontend/src/bundles/common/components/components.ts
@@ -1,4 +1,5 @@
 export { App } from '../../../app/app.js';
+export { Avatar, HeaderAvatar } from './avatar/components.js';
 export { Badge } from './badge/badge.js';
 export { Button } from './button/button.js';
 export { Checkbox } from './checkbox/checkbox.js';


### PR DESCRIPTION
one common avatar component based on mui avatar for project
includes: `HeaderAvatar` (for header) and `Avatar` (for other cases)
if we have to change default icon when there is no avatar image, we can put it inside in this way in
`frontend/src/bundles/common/components/avatar/components/avatar/avatar.tsx`
```jsx
<MUIAvatar {/* props... */}>
{/* put your icon/text here */}
</MUIAvatar>
```

![Screenshot 2023-09-05 221707](https://github.com/BinaryStudioAcademy/bsa-2023-bsa-talents/assets/24193459/db066bb0-da7f-41f3-97f2-9b533beb7130)

### values to test
```jsx
<Avatar src="https://cdn.pixabay.com/photo/2023/07/27/13/37/cottage-8153413_1280.jpg" />
<Avatar
    alt="hello"
    src="https://cdn.pixabay.com/broken-image.jpg"
/>
<Avatar small />
<Avatar alt="hello" />
<HeaderAvatar />
<HeaderAvatar isOnline />
<HeaderAvatar
    src="https://cdn.pixabay.com/photo/2023/08/13/00/09/woman-8186582_1280.jpg"
    isOnline
/>
```