### PR TITLE
fix/bt-318: bug the layout of the sign in page does not correspond to the approved design

### DIFF
--- a/mobile/src/bundles/auth/components/sign-in-form/sign-in-form.tsx
+++ b/mobile/src/bundles/auth/components/sign-in-form/sign-in-form.tsx
@@ -117,13 +117,13 @@ const SignInForm: React.FC<Properties> = ({ onSubmit }) => {
             <View
                 style={[
                     globalStyles.flexDirectionRow,
-                    globalStyles.justifyContentCenter,
-                    globalStyles.flex1,
-                    globalStyles.m20,
+                    globalStyles.justifyContentSpaceBetween,
+                    globalStyles.alignItemsCenter,
+                    globalStyles.m10,
                     styles.signUpWrapper,
                 ]}
             >
-                <Text style={styles.text}>Not Registered Yet? </Text>
+                <Text style={[styles.text]}>Not Registered Yet?</Text>
                 <Link
                     style={styles.linkSignUp}
                     label="Create an account"

--- a/mobile/src/bundles/auth/components/sign-in-form/sign-in-form.tsx
+++ b/mobile/src/bundles/auth/components/sign-in-form/sign-in-form.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 
-import { type UserSignInRequestDto } from '~/bundles/auth/types/types';
+import { type UserSignInForm } from '~/bundles/auth/types/types';
 import { userSignInValidationSchema } from '~/bundles/auth/validation-schemas/validation-schemas';
 import {
     Button,
+    Checkbox,
     FormField,
     Input,
     Link,
@@ -11,24 +12,31 @@ import {
     View,
 } from '~/bundles/common/components/components';
 import { AuthScreenName, TextCategory } from '~/bundles/common/enums/enums';
-import { useAppForm, useCallback } from '~/bundles/common/hooks/hooks';
+import {
+    useAppForm,
+    useCallback,
+    useState,
+} from '~/bundles/common/hooks/hooks';
 import { globalStyles } from '~/bundles/common/styles/styles';
 
 import { USER_SIGN_IN_DEFAULT_VALUES } from './constants/constants';
 import { styles } from './styles';
 
 type Properties = {
-    onSubmit: (payload: UserSignInRequestDto) => void;
+    onSubmit: (payload: UserSignInForm) => void;
 };
 
 const SignInForm: React.FC<Properties> = ({ onSubmit }) => {
-    const { control, errors, handleSubmit } = useAppForm<UserSignInRequestDto>({
+    const { control, errors, handleSubmit } = useAppForm<UserSignInForm>({
         defaultValues: USER_SIGN_IN_DEFAULT_VALUES,
         validationSchema: userSignInValidationSchema,
     });
+    const [isRememberMeChecked, setIsRememberMeChecked] = useState(false);
     const handleFormSubmit = useCallback((): void => {
-        void handleSubmit(onSubmit)();
-    }, [handleSubmit, onSubmit]);
+        void handleSubmit((userData) => {
+            onSubmit({ ...userData, isRememberMeChecked });
+        })();
+    }, [isRememberMeChecked, handleSubmit, onSubmit]);
 
     return (
         <View
@@ -51,7 +59,7 @@ const SignInForm: React.FC<Properties> = ({ onSubmit }) => {
             <View style={styles.formWrapper}>
                 <FormField
                     errorMessage={errors.email?.message}
-                    label="Email"
+                    label="Email*"
                     name="email"
                 >
                     <Input
@@ -62,7 +70,7 @@ const SignInForm: React.FC<Properties> = ({ onSubmit }) => {
                 </FormField>
                 <FormField
                     errorMessage={errors.password?.message}
-                    label="Password"
+                    label="Password*"
                     name="password"
                 >
                     <Input
@@ -72,16 +80,33 @@ const SignInForm: React.FC<Properties> = ({ onSubmit }) => {
                         secureTextEntry
                     />
                 </FormField>
-                <Link
-                    textComponentCategory={TextCategory.CAPTION}
+                <View
                     style={[
-                        globalStyles.alignSelfFlexEnd,
-                        globalStyles.pr10,
-                        styles.linkForgotPassword,
+                        globalStyles.flexDirectionRow,
+                        globalStyles.ph25,
+                        globalStyles.justifyContentSpaceAround,
+                        globalStyles.alignItemsCenter,
                     ]}
-                    label="Forgot Password?"
-                    link={`/${AuthScreenName.SIGN_UP}`}
-                />
+                >
+                    <Checkbox
+                        label="Remember Me"
+                        isChecked={isRememberMeChecked}
+                        onChange={(): void => {
+                            setIsRememberMeChecked(!isRememberMeChecked);
+                        }}
+                    />
+                    <Link
+                        textComponentCategory={TextCategory.CAPTION}
+                        style={[
+                            globalStyles.alignSelfFlexEnd,
+                            globalStyles.pr10,
+                            styles.linkForgotPassword,
+                        ]}
+                        label="Forgot Password?"
+                        link={`/${AuthScreenName.SIGN_UP}`}
+                    />
+                    {/* TODO: Create forget password logic */}
+                </View>
 
                 <Button
                     style={[globalStyles.mb15, globalStyles.pv15]}
@@ -93,7 +118,9 @@ const SignInForm: React.FC<Properties> = ({ onSubmit }) => {
                 style={[
                     globalStyles.flexDirectionRow,
                     globalStyles.justifyContentCenter,
-                    globalStyles.mt20,
+                    globalStyles.flex1,
+                    globalStyles.m20,
+                    styles.signUpWrapper,
                 ]}
             >
                 <Text style={styles.text}>Not Registered Yet? </Text>

--- a/mobile/src/bundles/auth/components/sign-in-form/styles.ts
+++ b/mobile/src/bundles/auth/components/sign-in-form/styles.ts
@@ -20,6 +20,9 @@ const styles = StyleSheet.create({
         color: Color.PRIMARY,
         fontFamily: FontFamily.INTER_SEMIBOLD,
     },
+    signUpWrapper: {
+        flexWrap: 'wrap',
+    },
     formWrapper: {
         gap: 25,
     },

--- a/mobile/src/bundles/auth/components/sign-in-form/styles.ts
+++ b/mobile/src/bundles/auth/components/sign-in-form/styles.ts
@@ -22,6 +22,8 @@ const styles = StyleSheet.create({
     },
     signUpWrapper: {
         flexWrap: 'wrap',
+        flexShrink: 1,
+        gap: 5,
     },
     formWrapper: {
         gap: 25,

--- a/mobile/src/bundles/auth/screens/auth.tsx
+++ b/mobile/src/bundles/auth/screens/auth.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { actions as authActions } from '~/bundles/auth/store';
 import {
-    type UserSignInRequestDto,
+    type UserSignInForm,
     type UserSignUpRequestDto,
 } from '~/bundles/auth/types/types';
 import { Overlay } from '~/bundles/common/components/components';
@@ -31,7 +31,7 @@ const Auth: React.FC = () => {
     }, [isSignUpScreen, dispatch]);
 
     const handleSignInSubmit = useCallback(
-        (payload: UserSignInRequestDto): void => {
+        (payload: UserSignInForm): void => {
             void dispatch(authActions.signIn(payload));
         },
         [dispatch],

--- a/mobile/src/bundles/auth/store/actions.ts
+++ b/mobile/src/bundles/auth/store/actions.ts
@@ -1,7 +1,7 @@
 import { createAsyncThunk } from '@reduxjs/toolkit';
 
 import {
-    type UserSignInRequestDto,
+    type UserSignInForm,
     type UserSignInResponseDto,
     type UserSignUpRequestDto,
     type UserSignUpResponseDto,
@@ -32,13 +32,16 @@ const signUp = createAsyncThunk<
 
 const signIn = createAsyncThunk<
     UserSignInResponseDto,
-    UserSignInRequestDto,
+    UserSignInForm,
     AsyncThunkConfig
 >(`${sliceName}/sign-in`, async (signInPayload, { extra }) => {
     const { authApi, storage, notifications } = extra;
     try {
-        const response = await authApi.signIn(signInPayload);
-        await storage.set(StorageKey.TOKEN, response.token);
+        const { isRememberMeChecked, ...signInData } = signInPayload;
+        const response = await authApi.signIn(signInData);
+        if (isRememberMeChecked) {
+            await storage.set(StorageKey.TOKEN, response.token);
+        }
         return response;
     } catch (error) {
         const errorMessage = getErrorMessage(error);

--- a/mobile/src/bundles/auth/types/types.ts
+++ b/mobile/src/bundles/auth/types/types.ts
@@ -1,3 +1,4 @@
+export { type UserSignInForm } from './user-sign-in-form';
 export {
     type UserGetAllItemResponseDto,
     type UserGetAllResponseDto,

--- a/mobile/src/bundles/auth/types/user-sign-in-form.ts
+++ b/mobile/src/bundles/auth/types/user-sign-in-form.ts
@@ -1,0 +1,7 @@
+import { type UserSignInRequestDto } from 'shared/build/bundles/users/types/user-sign-in-request-dto.type';
+
+type UserSignInForm = {
+    isRememberMeChecked: boolean;
+} & UserSignInRequestDto;
+
+export { type UserSignInForm };


### PR DESCRIPTION
If text description would grater than background, text will wrap on the next line
<img width="185" alt="image" src="https://github.com/BinaryStudioAcademy/bsa-2023-bsa-talents/assets/85788646/0518d513-ace5-45c3-81a9-691df6c0a32d">
