### PR TITLE
bt-395: Wrong name of the "Experience" field on Step 01

### DIFF
--- a/mobile/src/bundles/talent/components/profile-form/profile-form.tsx
+++ b/mobile/src/bundles/talent/components/profile-form/profile-form.tsx
@@ -117,7 +117,7 @@ const ProfileForm: React.FC<Properties> = ({ profileStepData, onSubmit }) => {
             </FormField>
             <FormField
                 errorMessage={errors.experienceYears?.message}
-                label="Experience Level"
+                label="Experience"
                 name="experienceYears"
                 required
                 containerStyle={globalStyles.pb25}


### PR DESCRIPTION
<img width="380" alt="Screenshot 2023-09-13 at 15 06 39" src="https://github.com/BinaryStudioAcademy/bsa-2023-bsa-talents/assets/70234990/3fb8a8bf-06bf-4e9d-ab6d-4ffc7face61f">
