### PR TITLE
bt-475: Remove Back button from Step 1

### DIFF
--- a/frontend/src/bundles/talent-onboarding/components/step-content/step-content.tsx
+++ b/frontend/src/bundles/talent-onboarding/components/step-content/step-content.tsx
@@ -57,26 +57,28 @@ const StepContent: React.FC<Properties> = ({
                             : styles.stepButtons,
                     )}
                 >
-                    <Button
-                        onClick={
-                            currentStep === STEPS_NUMBER
-                                ? undefined
-                                : onPreviousStep
-                        }
-                        label={
-                            currentStep === STEPS_NUMBER
-                                ? 'Save without publishing'
-                                : 'Back'
-                        }
-                        variant={
-                            currentStep === STEP_ONE ? 'contained' : 'outlined'
-                        }
-                        className={getValidClassNames(
-                            styles.button,
-                            styles.buttonBack,
-                        )}
-                        disabled={currentStep === STEP_ONE}
-                    />
+                    {currentStep !== STEP_ONE && (
+                        <Button
+                            onClick={
+                                currentStep === STEPS_NUMBER
+                                    ? undefined
+                                    : onPreviousStep
+                            }
+                            label={
+                                currentStep === STEPS_NUMBER
+                                    ? 'Save without publishing'
+                                    : 'Back'
+                            }
+                            variant="outlined"
+                            className={getValidClassNames(
+                                styles.button,
+                                styles.buttonBack,
+                            )}
+                        />
+                    )}
+                    {currentStep === STEP_ONE && (
+                        <Grid className={styles.buttonPlaceholder} />
+                    )}
                     <Button
                         onClick={
                             currentStep === STEPS_NUMBER

--- a/frontend/src/bundles/talent-onboarding/components/step-content/styles.module.scss
+++ b/frontend/src/bundles/talent-onboarding/components/step-content/styles.module.scss
@@ -57,6 +57,9 @@
 }
 
 .stepButtons {
+    display: flex;
+    align-items: center;
+
     .button {
         width: 104px;
         height: 36px;
@@ -64,6 +67,13 @@
         font-weight: 500;
         font-size: 13px;
         text-transform: capitalize;
+    }
+
+    .buttonPlaceholder {
+        display: inline-block;
+        width: 104px;
+        height: 36px;
+        margin: 5px;
     }
 }
 
@@ -95,6 +105,12 @@
         font-size: 13px;
         text-transform: none;
     }
+
+    .buttonPlaceholder {
+        width: 181px;
+        height: 36px;
+        margin: 7px;
+    }
 }
 
 .stepOutlet {
@@ -103,7 +119,7 @@
     align-items: center;
 }
 
-@media screen and (width <= 660px) {
+@media screen and (width <=660px) {
     .stepName {
         font-size: 15px;
     }
@@ -118,10 +134,19 @@
         .button {
             width: 60px;
         }
+
+        .buttonPlaceholder {
+            width: 60px;
+        }
     }
 
     .wideStepButtons {
         .button {
+            width: 120px;
+            height: 50px;
+        }
+
+        .buttonPlaceholder {
             width: 120px;
             height: 50px;
         }


### PR DESCRIPTION
closes #475 
![image](https://github.com/BinaryStudioAcademy/bsa-2023-bsa-talents/assets/68593365/773b1efe-7e8a-4466-867e-ecc4ae78bc87)
There's no point in this button since user can't go Back from the first step. Next button should be placed in the same place and remain untouched.