### PR TITLE
bt-633: [BUG] Margin below Hard Skills on Search page is too big

### DIFF
--- a/frontend/src/bundles/common/components/autocomplete/styles.module.scss
+++ b/frontend/src/bundles/common/components/autocomplete/styles.module.scss
@@ -27,6 +27,10 @@
 
 .chips {
     margin-top: 13px;
+
+    &:empty {
+        display: none;
+    }
 }
 
 .input {


### PR DESCRIPTION
Closes #633 

![image](https://github.com/BinaryStudioAcademy/bsa-2023-bsa-talents/assets/42421305/d709cd4a-46c3-4a47-a334-6b55f8d02c67)

![image](https://github.com/BinaryStudioAcademy/bsa-2023-bsa-talents/assets/42421305/b2000580-6b60-4c82-9ae0-181c94c8d098)
