### PR TITLE
bt-782: [BUG ] Employer Name not showing + chat page improvements

### DIFF
--- a/backend/src/bundles/chat-messages/helpers/chat-dto-to-chat-response-dto.ts
+++ b/backend/src/bundles/chat-messages/helpers/chat-dto-to-chat-response-dto.ts
@@ -11,12 +11,14 @@ const chatDtoToChatResponseDto = (chat: ChatItem): ChatResponseDto => {
         participants: {
             sender: {
                 id: sender.userId,
+                fullName: sender.fullName,
                 profileName: sender.profileName,
                 companyName: sender.companyName,
                 avatarUrl: sender.photo ? sender.photo.url : '',
             },
             receiver: {
                 id: receiver.userId,
+                fullName: receiver.fullName,
                 profileName: receiver.profileName,
                 companyName: receiver.companyName,
                 avatarUrl: receiver.photo ? receiver.photo.url : '',

--- a/frontend/src/bundles/chat/components/chat-header/chat-header.tsx
+++ b/frontend/src/bundles/chat/components/chat-header/chat-header.tsx
@@ -1,5 +1,6 @@
 import { UserRole } from 'shared/build/index.js';
 
+import { getChatHeaderProps as getChatHeaderProperties } from '~/bundles/chat/helpers/get-chat-header-props.js';
 import {
     Avatar,
     Grid,
@@ -11,7 +12,6 @@ import { getValidClassNames } from '~/bundles/common/helpers/helpers.js';
 import { useAppSelector } from '~/bundles/common/hooks/hooks.js';
 import { type ApplicationRoute } from '~/bundles/common/types/application-route.type.js';
 
-import { getChatHeaderProps as getChatHeaderProperties } from '../../helpers/get-chat-header-props.js';
 import styles from './styles.module.scss';
 
 type Properties = {

--- a/frontend/src/bundles/chat/components/chat-header/chat-header.tsx
+++ b/frontend/src/bundles/chat/components/chat-header/chat-header.tsx
@@ -11,25 +11,20 @@ import { getValidClassNames } from '~/bundles/common/helpers/helpers.js';
 import { useAppSelector } from '~/bundles/common/hooks/hooks.js';
 import { type ApplicationRoute } from '~/bundles/common/types/application-route.type.js';
 
+import { getChatHeaderProps as getChatHeaderProperties } from '../../helpers/get-chat-header-props.js';
 import styles from './styles.module.scss';
 
 type Properties = {
-    avatarUrl?: string;
     className?: string;
     isOnline: boolean;
-    title: string;
     userId: string;
 };
 
-const ChatHeader: React.FC<Properties> = ({
-    avatarUrl,
-    className,
-    isOnline,
-    title,
-    userId,
-}) => {
-    const { role, isLoading, currentChatId } = useAppSelector(
+const ChatHeader: React.FC<Properties> = ({ className, isOnline, userId }) => {
+    const { role, isLoading, currentChatId, chats, user } = useAppSelector(
         ({ auth, chat }) => ({
+            user: auth.currentUser,
+            chats: chat.chats,
             role: auth.currentUser?.role,
             isLoading: chat.dataStatus === 'pending',
             currentChatId: chat.current.chatId,
@@ -39,6 +34,15 @@ const ChatHeader: React.FC<Properties> = ({
         styles.icon,
         isOnline ? styles.online : styles.offline,
     );
+
+    const { chatHeaderName: title, chatHeaderAvatar: avatarUrl } =
+        getChatHeaderProperties({
+            chats,
+            selectedId: currentChatId,
+            userId: user?.id,
+            userRole: user?.role,
+        });
+
     const infoLink: ApplicationRoute = AppRoute.CANDIDATE.replace(
         ':userId',
         userId,

--- a/frontend/src/bundles/chat/components/chat-list/chat-item/styles.module.scss
+++ b/frontend/src/bundles/chat/components/chat-list/chat-item/styles.module.scss
@@ -38,3 +38,15 @@
     white-space: nowrap;
     text-overflow: ellipsis;
 }
+
+@media screen and (width >= 900px) {
+    .date {
+        display: none;
+    }
+}
+
+@media screen and (width >= 1200px) {
+    .date {
+        display: unset;
+    }
+}

--- a/frontend/src/bundles/chat/components/chat-list/chat-list.tsx
+++ b/frontend/src/bundles/chat/components/chat-list/chat-list.tsx
@@ -1,4 +1,5 @@
 import { formatDistanceToNowStrict } from 'date-fns';
+import { UserRole } from 'shared/build/index.js';
 
 import { Grid } from '~/bundles/common/components/components.js';
 import {
@@ -35,15 +36,18 @@ const ChatList: React.FC<Properties> = ({ onItemClick }) => {
 
         const { receiver, sender } = chat.participants;
         const partner = user?.id === receiver.id ? sender : receiver;
+        const isEmployer = user?.role === UserRole.EMPLOYER;
 
         return {
             chatId: chat.chatId,
             userId: user?.id as string,
-            username: partner.profileName ?? '',
+            username: isEmployer
+                ? (partner.profileName as string)
+                : (partner.fullName as string),
             lastMessage: chat.lastMessage,
             lastMessageDate: `${timeSince} ago`,
             avatar: partner.avatarUrl,
-            fullName: partner.profileName ?? '',
+            fullName: isEmployer ? partner.profileName : partner.fullName,
             isSelected: currentChatId === chat.chatId,
             receiver,
             sender,

--- a/frontend/src/bundles/chat/components/chat-placeholder/chat-placeholder.tsx
+++ b/frontend/src/bundles/chat/components/chat-placeholder/chat-placeholder.tsx
@@ -1,0 +1,31 @@
+import { Grid } from '~/bundles/common/components/components.js';
+import { UserRole } from '~/bundles/common/enums/enums.js';
+import { useAppSelector } from '~/bundles/common/hooks/hooks.js';
+
+import {
+    EMPLOYER_CHAT_PLACEHOLDER,
+    TALENT_CHAT_PLACEHOLDER,
+} from '../../constants/constants.js';
+import styles from './styles.module.scss';
+
+type Properties = {
+    className?: string;
+};
+
+const ChatPlaceholder: React.FC<Properties> = ({ className }) => {
+    const { user } = useAppSelector(({ auth }) => ({
+        user: auth.currentUser,
+    }));
+
+    return (
+        <Grid className={className}>
+            <p className={styles.noChatsPlaceholder}>
+                {user?.role === UserRole.EMPLOYER
+                    ? EMPLOYER_CHAT_PLACEHOLDER
+                    : TALENT_CHAT_PLACEHOLDER}
+            </p>
+        </Grid>
+    );
+};
+
+export { ChatPlaceholder };

--- a/frontend/src/bundles/chat/components/chat-placeholder/styles.module.scss
+++ b/frontend/src/bundles/chat/components/chat-placeholder/styles.module.scss
@@ -1,0 +1,10 @@
+.noChatsPlaceholder {
+    max-width: 80%;
+    margin: 0 auto;
+    color: var(--text-primary);
+    font-weight: var(--font-weight-medium);
+    font-size: clamp(2vw, var(--font-size-h2), 5vw);
+    font-family: var(--font-family);
+    line-height: var(--line-height-h2-h4);
+    text-align: center;
+}

--- a/frontend/src/bundles/chat/components/components.ts
+++ b/frontend/src/bundles/chat/components/components.ts
@@ -1,5 +1,6 @@
 export { ChatHeader } from './chat-header/chat-header.js';
 export { ChatList } from './chat-list/chat-list.js';
+export { ChatPlaceholder } from './chat-placeholder/chat-placeholder.js';
 export { CompanyInfo } from './company-info/company-info.js';
 export { MessageInput } from './message-input/message-input.js';
 export { MessageItem } from './message-item/message-item.js';

--- a/frontend/src/bundles/chat/components/message-list/message-list.tsx
+++ b/frontend/src/bundles/chat/components/message-list/message-list.tsx
@@ -28,12 +28,14 @@ const MessageList: React.FC<Properties> = ({ className }) => {
 
     let receiver: ChatParticipantDto = {
         id: '',
+        fullName: '',
         profileName: '',
         companyName: '',
         avatarUrl: '',
     };
     let sender: ChatParticipantDto = {
         id: '',
+        fullName: '',
         profileName: '',
         companyName: '',
         avatarUrl: '',

--- a/frontend/src/bundles/chat/constants/constants.ts
+++ b/frontend/src/bundles/chat/constants/constants.ts
@@ -3,4 +3,16 @@ const ZERO_INDEX = 0;
 const NO_MESSAGES = 0;
 const NO_CHATS = 0;
 
-export { MAX_MESSAGE_LENGTH, NO_CHATS, NO_MESSAGES, ZERO_INDEX };
+const TALENT_CHAT_PLACEHOLDER =
+    'There are no active conversations yet. When employers want to contact you, all chats will be here';
+const EMPLOYER_CHAT_PLACEHOLDER =
+    'There are no active conversations yet. When you contact a candidate, all chats will be here';
+
+export {
+    EMPLOYER_CHAT_PLACEHOLDER,
+    MAX_MESSAGE_LENGTH,
+    NO_CHATS,
+    NO_MESSAGES,
+    TALENT_CHAT_PLACEHOLDER,
+    ZERO_INDEX,
+};

--- a/frontend/src/bundles/chat/helpers/get-chat-header-props.ts
+++ b/frontend/src/bundles/chat/helpers/get-chat-header-props.ts
@@ -1,3 +1,5 @@
+import { UserRole } from 'shared/build/index.js';
+
 import { type ChatResponseDto } from '../types/types.js';
 
 type Return = {
@@ -9,10 +11,12 @@ const getChatHeaderProperties = ({
     chats,
     selectedId,
     userId,
+    userRole,
 }: {
     chats: ChatResponseDto[];
     selectedId: string | null;
     userId: string | undefined;
+    userRole: string | undefined;
 }): Return => {
     const match = chats.find((it) => it.chatId === selectedId);
     const returnObject: Return = {
@@ -23,12 +27,13 @@ const getChatHeaderProperties = ({
     if (match) {
         const { receiver, sender } = match.participants;
         const isUserSender = userId === sender.id;
+        const partner = isUserSender ? receiver : sender;
 
-        returnObject.chatHeaderAvatar = isUserSender
-            ? receiver.avatarUrl
-            : sender.avatarUrl;
+        returnObject.chatHeaderAvatar = partner.avatarUrl;
         returnObject.chatHeaderName =
-            (isUserSender ? receiver.profileName : sender.profileName) ?? '';
+            userRole === UserRole.EMPLOYER
+                ? (partner.profileName as string)
+                : (partner.fullName as string);
     }
 
     return returnObject;

--- a/frontend/src/bundles/chat/pages/chats/chats-page.tsx
+++ b/frontend/src/bundles/chat/pages/chats/chats-page.tsx
@@ -5,6 +5,7 @@ import { actions as candidateActions } from '~/bundles/candidate-details/store/c
 import {
     ChatHeader,
     ChatList,
+    ChatPlaceholder,
     CompanyInfo,
     MessageInput,
     MessageList,
@@ -34,7 +35,6 @@ import {
     ChatListIcon,
 } from '../../components/small-screen-button/components.js';
 import { NO_CHATS } from '../../constants/constants.js';
-import { getChatHeaderProps as getChatHeaderProperties } from '../../helpers/get-chat-header-props.js';
 import styles from './styles.module.scss';
 
 const ChatsPage: React.FC = () => {
@@ -61,15 +61,15 @@ const ChatsPage: React.FC = () => {
 
     const dispatch = useAppDispatch();
 
-    const { user, chats, currentChatId, isLoading, employerId, talentId } =
-        useAppSelector(({ auth, chat }) => ({
+    const { user, chats, isLoading, employerId, talentId } = useAppSelector(
+        ({ auth, chat }) => ({
             user: auth.currentUser,
             chats: chat.chats,
-            currentChatId: chat.current.chatId,
             employerId: chat.current.employerDetails.employerId ?? '',
             talentId: chat.current.talentId ?? '',
             isLoading: chat.dataStatus === 'pending',
-        }));
+        }),
+    );
 
     //  Get list of all chats this user is participating in and store:
     useEffect(() => {
@@ -126,11 +126,6 @@ const ChatsPage: React.FC = () => {
         };
     }, [dispatch, user?.id]);
 
-    const { chatHeaderName, chatHeaderAvatar } = getChatHeaderProperties({
-        chats,
-        selectedId: currentChatId,
-        userId: user?.id,
-    });
     const headerUserId =
         user?.role === UserRole.EMPLOYER ? talentId : employerId;
 
@@ -219,10 +214,8 @@ const ChatsPage: React.FC = () => {
                             )}
                             <ChatHeader
                                 userId={headerUserId}
-                                title={chatHeaderName}
                                 isOnline
                                 className={styles.chatHeader}
-                                avatarUrl={chatHeaderAvatar}
                             />
                             <MessageList className={styles.messageList} />
                             <MessageInput className={styles.chatInput} />
@@ -252,18 +245,12 @@ const ChatsPage: React.FC = () => {
                 </>
             ) : (
                 !isLoading && (
-                    <Grid
+                    <ChatPlaceholder
                         className={getValidClassNames(
                             styles.chatWrapper,
                             styles.empty,
                         )}
-                    >
-                        <p className={styles.noChatsPlaceholder}>
-                            There are no active conversations yet. When
-                            employers want to contact you, all chats will be
-                            here
-                        </p>
-                    </Grid>
+                    />
                 )
             )}
         </Grid>

--- a/frontend/src/bundles/chat/pages/chats/styles.module.scss
+++ b/frontend/src/bundles/chat/pages/chats/styles.module.scss
@@ -118,17 +118,6 @@
     font-size: var(--font-size-h4);
 }
 
-.noChatsPlaceholder {
-    max-width: 80%;
-    margin: 0 auto;
-    color: var(--text-primary);
-    font-weight: var(--font-weight-medium);
-    font-size: clamp(2vw, var(--font-size-h2), 5vw);
-    font-family: var(--font-family);
-    line-height: var(--line-height-h2-h4);
-    text-align: center;
-}
-
 .chatWrapper.empty {
     display: flex;
     align-items: center;

--- a/shared/src/bundles/chat-messages/types/chat-participant-dto.type.ts
+++ b/shared/src/bundles/chat-messages/types/chat-participant-dto.type.ts
@@ -1,5 +1,6 @@
 type ChatParticipantDto = {
     id: string;
+    fullName: string | null;
     profileName: string | null;
     companyName: string | null;
     avatarUrl: string;


### PR DESCRIPTION
Closes #782 

- Fixed logic for showing employer name correctly.
- Removed overflowing time since chat for screens 900 > 1200 (tablet)
- Add placeholder for employers with empty chats.


![image](https://github.com/BinaryStudioAcademy/bsa-2023-bsa-talents/assets/90120572/50fc9b00-4a4e-455d-b1a7-2f3de5fd9c61)
