### PR TITLE
bt-616: Photo and logo fields are displayed too close to the form on the Employer onboarding page

### DIFF
--- a/frontend/src/bundles/employer-onboarding/components/onboarding-form/styles.module.scss
+++ b/frontend/src/bundles/employer-onboarding/components/onboarding-form/styles.module.scss
@@ -1,5 +1,5 @@
 .formWrapper {
-    width: 100%;
+    width: 65vw;
 }
 
 .form {
@@ -11,7 +11,7 @@
 
 .formFields {
     gap: 10px;
-    width: 50%;
+    width: 60%;
 }
 
 .formField {
@@ -155,6 +155,10 @@
 @media screen and (width <=1240px) {
     .formInput {
         width: 60%;
+    }
+
+    .formWrapper {
+        width: 70vw;
     }
 }
 

--- a/frontend/src/bundles/employer-onboarding/components/onboarding-form/styles.module.scss
+++ b/frontend/src/bundles/employer-onboarding/components/onboarding-form/styles.module.scss
@@ -5,7 +5,7 @@
 .form {
     display: flex;
     justify-content: space-between;
-    gap: 10px;
+    gap: 12.5%;
     width: 100%;
 }
 
@@ -23,6 +23,7 @@
 
 .formInput {
     width: 70%;
+    min-width: 70%;
 }
 
 .formTextarea {
@@ -143,6 +144,12 @@
     color: var(--text-primary-dark);
     background-color: var(--solitude);
     border-radius: 4px;
+}
+
+@media screen and (width >=1600px) {
+    .photoContainer {
+        margin: 0 auto;
+    }
 }
 
 @media screen and (width <=1240px) {

--- a/frontend/src/bundles/employer-onboarding/pages/onboarding/onboarding.tsx
+++ b/frontend/src/bundles/employer-onboarding/pages/onboarding/onboarding.tsx
@@ -49,7 +49,7 @@ const Onboarding: React.FC = () => {
                             </Typography>
                         </Grid>
                         <OnboardingForm />
-                        <Grid>
+                        <Grid className={styles.buttonContainer}>
                             <Button
                                 type="submit"
                                 variant="outlined"

--- a/frontend/src/bundles/profile-cabinet/pages/profile-cabinet.tsx
+++ b/frontend/src/bundles/profile-cabinet/pages/profile-cabinet.tsx
@@ -188,7 +188,7 @@ const ProfileCabinet: React.FC = () => {
                                     label={
                                         role === UserRole.TALENT
                                             ? 'Publish now'
-                                            : 'Submit for varification'
+                                            : 'Submit for verification'
                                     }
                                     variant={'contained'}
                                     className={getValidClassNames(

--- a/package-lock.json
+++ b/package-lock.json
@@ -78,7 +78,6 @@
         },
         "backend/node_modules/node-fetch": {
             "version": "3.3.2",
-            "license": "MIT",
             "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
             "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
             "license": "MIT",


### PR DESCRIPTION
Closes #616 and #695 
![image](https://github.com/BinaryStudioAcademy/bsa-2023-bsa-talents/assets/68593365/63edfc5e-4b7c-4305-8ed8-f81ddc82385d)
![image](https://github.com/BinaryStudioAcademy/bsa-2023-bsa-talents/assets/68593365/e7207434-5cfd-4e73-8d11-6412902443e4)
![image](https://github.com/BinaryStudioAcademy/bsa-2023-bsa-talents/assets/68593365/1522ef3c-33f6-422f-8ce6-e8f7023887a4)
![image](https://github.com/BinaryStudioAcademy/bsa-2023-bsa-talents/assets/68593365/3a0b3464-784e-4854-a4f4-092cf12dc24b)
