### PR TITLE
bt-814:  Add CV and Profile link to shared CV message

### DIFF
--- a/frontend/src/bundles/chat/components/company-info/company-info.tsx
+++ b/frontend/src/bundles/chat/components/company-info/company-info.tsx
@@ -4,6 +4,7 @@ import {
     Avatar,
     Button,
     Grid,
+    Logo,
     Typography,
 } from '~/bundles/common/components/components.js';
 import {
@@ -11,10 +12,15 @@ import {
     useAppSelector,
     useCallback,
 } from '~/bundles/common/hooks/hooks.js';
+import { userDetailsApi } from '~/bundles/user-details/user-details.js';
 
 import styles from './styles.module.scss';
 
-const CompanyInfo: React.FC = () => {
+type Properties = {
+    className?: string;
+};
+
+const CompanyInfo: React.FC<Properties> = ({ className }) => {
     const { company, hasSharedContacts, talentId, employerId, currentChatId } =
         useAppSelector(({ chat }) => ({
             company: chat.current.employerDetails,
@@ -35,16 +41,32 @@ const CompanyInfo: React.FC = () => {
     } = company;
 
     const handleShareCVButtonClick = useCallback(() => {
-        void dispatch(
-            chatActions.createMessage({
-                message:
-                    'Hello!\n I have shared my CV and information with you.',
-                senderId: talentId as string,
-                receiverId: employerId as string,
-                chatId: currentChatId as string,
-            }),
-        );
-        void dispatch(candidateActions.shareContactsWithCompany());
+        const createNotificationMessage = async (): Promise<void> => {
+            const userDetails = await userDetailsApi.getFullUserDetailsById({
+                userId: talentId as string,
+            });
+
+            const cvUrl = userDetails.cv?.url;
+            const baseUrl = window.location.toString().replace('/chats', '');
+
+            void dispatch(
+                chatActions.createMessage({
+                    message:
+                        'Hello!\n I have shared my CV and information with you.\n\n ' +
+                        'CV:\n ' +
+                        `${cvUrl} ` +
+                        '\nProfile:\n ' +
+                        `${baseUrl}/candidates/${talentId} `,
+                    senderId: talentId as string,
+                    receiverId: employerId as string,
+                    chatId: currentChatId as string,
+                }),
+            );
+
+            void dispatch(candidateActions.shareContactsWithCompany());
+        };
+
+        void createNotificationMessage();
     }, [dispatch, currentChatId, employerId, talentId]);
 
     const handleAlreadyHiredButtonClick = useCallback(() => {
@@ -52,7 +74,7 @@ const CompanyInfo: React.FC = () => {
     }, []);
 
     const aboutInfo = about ?? 'No information provided';
-    return (
+    return currentChatId ? (
         <Grid className={styles.wrapper}>
             <Grid className={styles.header}>
                 <Avatar
@@ -126,6 +148,13 @@ const CompanyInfo: React.FC = () => {
                     />
                 </Grid>
             </Grid>
+        </Grid>
+    ) : (
+        <Grid className={className}>
+            <Logo isCollapsed />
+            <span className={styles.hire}>
+                Where great talent meets great opportunities
+            </span>
         </Grid>
     );
 };

--- a/frontend/src/bundles/chat/components/company-info/company-info.tsx
+++ b/frontend/src/bundles/chat/components/company-info/company-info.tsx
@@ -53,10 +53,8 @@ const CompanyInfo: React.FC<Properties> = ({ className }) => {
                 chatActions.createMessage({
                     message:
                         'Hello!\n I have shared my CV and information with you.\n\n ' +
-                        'CV:\n ' +
-                        `${cvUrl} ` +
-                        '\nProfile:\n ' +
-                        `${baseUrl}/candidates/${talentId} `,
+                        `CV_&_${cvUrl} ` +
+                        `Profile_&_${baseUrl}/candidates/${talentId} `,
                     senderId: talentId as string,
                     receiverId: employerId as string,
                     chatId: currentChatId as string,

--- a/frontend/src/bundles/chat/components/company-info/styles.module.scss
+++ b/frontend/src/bundles/chat/components/company-info/styles.module.scss
@@ -117,3 +117,15 @@
     text-decoration: underline;
     background-color: transparent;
 }
+
+:global(.message-link) {
+    display: block;
+    color: var(--text-primary-dark);
+}
+
+.hire {
+    margin-top: 15px;
+    font-size: var(--font-size-h4);
+    line-height: var(--line-height-h2-h4);
+    text-align: center;
+}

--- a/frontend/src/bundles/chat/components/message-item/message-item.tsx
+++ b/frontend/src/bundles/chat/components/message-item/message-item.tsx
@@ -11,7 +11,7 @@ import styles from './styles.module.scss';
 type Properties = {
     avatarUrl?: string;
     userId: string;
-    children: string;
+    children: string | JSX.Element;
     userFullName: string;
 };
 

--- a/frontend/src/bundles/chat/components/message-list/message-list.tsx
+++ b/frontend/src/bundles/chat/components/message-list/message-list.tsx
@@ -6,6 +6,7 @@ import {
     useEffect,
     useRef,
 } from '~/bundles/common/hooks/hooks.js';
+import { parseMessage } from '~/helpers/parse-messages.helper.js';
 
 import { NO_MESSAGES } from '../../constants/constants.js';
 import { MessageItem } from '../components.js';
@@ -68,18 +69,22 @@ const MessageList: React.FC<Properties> = ({ className }) => {
             });
         }
     }, [messages.length]);
+
     return (
         <Grid className={getValidClassNames(styles.messageList, className)}>
-            {messages.map((message) => (
-                <MessageItem
-                    key={message.id}
-                    userId={message.userId}
-                    userFullName={message.userFullName}
-                    avatarUrl={message.avatar}
-                >
-                    {message.value}
-                </MessageItem>
-            ))}
+            {messages.map((message) => {
+                const messageValue = parseMessage(message.value);
+                return (
+                    <MessageItem
+                        key={message.id}
+                        userId={message.userId}
+                        userFullName={message.userFullName}
+                        avatarUrl={message.avatar}
+                    >
+                        {messageValue}
+                    </MessageItem>
+                );
+            })}
             <div ref={autoScrollElement} className={styles.autoScrollElement} />
         </Grid>
     );

--- a/frontend/src/bundles/chat/pages/chats/chats-page.tsx
+++ b/frontend/src/bundles/chat/pages/chats/chats-page.tsx
@@ -230,7 +230,9 @@ const ChatsPage: React.FC = () => {
                                 )}
                             >
                                 {user?.role === UserRole.TALENT ? (
-                                    <CompanyInfo />
+                                    <CompanyInfo
+                                        className={styles.placeholder}
+                                    />
                                 ) : (
                                     <div className={styles.placeholder}>
                                         <Logo isCollapsed />

--- a/frontend/src/helpers/helpers.ts
+++ b/frontend/src/helpers/helpers.ts
@@ -1,3 +1,4 @@
+export { parseMessage } from './parse-messages.helper.js';
 export {
     type ChatListItemType,
     configureString,

--- a/frontend/src/helpers/parse-messages.helper.tsx
+++ b/frontend/src/helpers/parse-messages.helper.tsx
@@ -1,0 +1,33 @@
+const URL_REGEX =
+    /^(http:\/\/www\.|https:\/\/www\.|http:\/\/|https:\/\/|www\.|localhost:)?(localhost|[\da-z]+([.-][\da-z]+)*\.[a-z]{2,5}(:\d{1,5})?(\/.*)?)$/gm;
+
+// TODO: LOCALHOST SHOULD BE REMOVED FOR PROD
+const LOCALHOST_URL_REGEX = /^https?:\/\/\w+(\.\w+)*(:\d+)?(\/.*)?$/gm;
+
+const parseMessage = (message: string): JSX.Element => {
+    const words = message.split(' ');
+
+    return (
+        <span>
+            {words.map((word) => {
+                return URL_REGEX.test(word) ||
+                    LOCALHOST_URL_REGEX.test(word) ? (
+                    <>
+                        <a
+                            className={'message-link'}
+                            href={word}
+                            target="_blank"
+                            rel="noreferrer"
+                        >
+                            {word}
+                        </a>{' '}
+                    </>
+                ) : (
+                    word + ' '
+                );
+            })}
+        </span>
+    );
+};
+
+export { parseMessage };

--- a/frontend/src/helpers/parse-messages.helper.tsx
+++ b/frontend/src/helpers/parse-messages.helper.tsx
@@ -10,20 +10,47 @@ const parseMessage = (message: string): JSX.Element => {
     return (
         <span>
             {words.map((word) => {
-                return URL_REGEX.test(word) ||
-                    LOCALHOST_URL_REGEX.test(word) ? (
+                const [link, specialPrefix] = word.split('_&_').reverse();
+                const isLink =
+                    URL_REGEX.test(link) || LOCALHOST_URL_REGEX.test(link);
+
+                const isCVLink = isLink && specialPrefix === 'CV';
+                const isProfileLink = isLink && specialPrefix === 'Profile';
+
+                let linkTo: string;
+                let label: string;
+
+                switch (true) {
+                    case isCVLink: {
+                        linkTo = link;
+                        label = 'Candidate CV';
+                        break;
+                    }
+                    case isProfileLink: {
+                        linkTo = link;
+                        label = 'Profile Information';
+                        break;
+                    }
+                    default: {
+                        linkTo = link;
+                        label = link;
+                        break;
+                    }
+                }
+
+                return isLink ? (
                     <>
                         <a
                             className={'message-link'}
-                            href={word}
+                            href={linkTo}
                             target="_blank"
                             rel="noreferrer"
                         >
-                            {word}
+                            {label}
                         </a>{' '}
                     </>
                 ) : (
-                    word + ' '
+                    label + ' '
                 );
             })}
         </span>


### PR DESCRIPTION
- Add Links to CV and Profile Card after sharing information. 
- Add right side placeholder for talents when no active chat is selected

Sample:
https://github.com/BinaryStudioAcademy/bsa-2023-bsa-talents/assets/90120572/1e253857-a1f0-46d4-b344-f821abf3c321

Talent screen when no chat selected yet:
![image](https://github.com/BinaryStudioAcademy/bsa-2023-bsa-talents/assets/90120572/b8aba6e6-dae4-410b-b395-5463f5523643)

Shared info:
![image](https://github.com/BinaryStudioAcademy/bsa-2023-bsa-talents/assets/90120572/9f6bf228-85d5-49a1-968e-1d9591b670cc)


